### PR TITLE
Miniconda link

### DIFF
--- a/content/pages/installation/osx/novice.md
+++ b/content/pages/installation/osx/novice.md
@@ -37,7 +37,7 @@ Therefore, we assume you are using one of these machines.
 The Python environment we will use is called **conda**, and it is provided by
 an installation package called **Miniconda**.
 
-**[Download Miniconda from here](http://cosnda.pydata.org/miniconda.html)**
+**[Download Miniconda from here](http://conda.pydata.org/miniconda.html)**
 
 Download the **Python 2** copy of Miniconda for OSX.
 


### PR DESCRIPTION
Minor typo: the miniconda link in OSX novice tutorial was wrong.
